### PR TITLE
add Deploy to Staging (#2)

### DIFF
--- a/.github/workflows/DeployStaging.yml
+++ b/.github/workflows/DeployStaging.yml
@@ -1,0 +1,13 @@
+name : Deploy to Staging
+
+on:
+  push:
+    branches:
+        - develop
+
+jobs:
+    deploy:
+        runs-on: ubuntu-latest
+        steps:
+        - name: Deploy Docker
+          run : curl ${{secrets.RENDER_DEPLOY_HOOK_DEVELOP}}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate deployments to the staging environment. The workflow is triggered by pushes to the `develop` branch and deploys using a Docker command.

New GitHub Actions workflow:

* [`.github/workflows/DeployStaging.yml`](diffhunk://#diff-3f7d98e016bd10e24bc0762ef29bb5fcb062bcbcfc4f1a9c49c61f98558eeacaR1-R13): Added a workflow named "Deploy to Staging" that triggers on pushes to the `develop` branch. It includes a job to deploy using a Docker command via a secret deployment hook (`RENDER_DEPLOY_HOOK_DEVELOP`).