### PR TITLE
add Deploy to Prod (#2)

### DIFF
--- a/.github/workflows/DeployProd.yml
+++ b/.github/workflows/DeployProd.yml
@@ -1,0 +1,13 @@
+name : Deploy to Staging
+
+on:
+  push:
+    branches:
+        - main
+
+jobs:
+    deploy:
+        runs-on: ubuntu-latest
+        steps:
+        - name: Deploy Docker
+          run : curl ${{secrets.RENDER_DEPLOY_HOOK}}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for deploying to the staging environment. The workflow is triggered on pushes to the `main` branch and deploys using a Docker deployment hook.

Deployment workflow changes:

* [`.github/workflows/DeployProd.yml`](diffhunk://#diff-c6d576c3a8f19378c7ce4c4705d1d29e96d1b823a68a204772d4b6ca5ea8b931R1-R13): Added a new workflow named "Deploy to Staging" that triggers on pushes to the `main` branch. It includes a single job to deploy using a Docker deployment hook via a secret environment variable (`RENDER_DEPLOY_HOOK`).