### PR TITLE
add needs build in deploy (#32)

### DIFF
--- a/.github/workflows/DeployProd.yml
+++ b/.github/workflows/DeployProd.yml
@@ -23,6 +23,7 @@ jobs:
           run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/feed-pulse-front:latest
     deploy:
         runs-on: ubuntu-latest
+        needs: build
         steps:
         - name: Deploy Docker
           run : curl ${{secrets.RENDER_DEPLOY_HOOK}}

--- a/.github/workflows/DeployStaging.yml
+++ b/.github/workflows/DeployStaging.yml
@@ -24,6 +24,7 @@ jobs:
 
     deploy:
         runs-on: ubuntu-latest
+        needs: build
         steps:
         - name: Deploy Docker
           run : curl ${{secrets.RENDER_DEPLOY_HOOK_DEVELOP}}


### PR DESCRIPTION
This pull request updates the deployment workflows for both production and staging environments by adding a dependency on the `build` job before running the `deploy` job. This ensures that the deployment process only starts after the build step is successfully completed.

Changes to deployment workflows:

* [`.github/workflows/DeployProd.yml`](diffhunk://#diff-c6d576c3a8f19378c7ce4c4705d1d29e96d1b823a68a204772d4b6ca5ea8b931R26): Added `needs: build` to the `deploy` job, making it dependent on the successful completion of the `build` job.
* [`.github/workflows/DeployStaging.yml`](diffhunk://#diff-3f7d98e016bd10e24bc0762ef29bb5fcb062bcbcfc4f1a9c49c61f98558eeacaR27): Added `needs: build` to the `deploy` job, ensuring the deployment process for staging also waits for the `build` job to finish.