### PR TITLE
fix Port (#32)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,5 @@ ENV PORT=3000
 
 EXPOSE $PORT
 
-
-CMD ["npm", "next", "start", "-p", "${PORT}"]
+CMD npx next start -p $PORT
 


### PR DESCRIPTION
This pull request makes a minor change to the `Dockerfile` to simplify the command used for starting the application.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L28-R28): Replaced the `CMD` instruction to use `npx next start -p $PORT` instead of `npm next start -p ${PORT}` for consistency and simplicity.